### PR TITLE
Bugfix/cross platform fix when using os.path.join

### DIFF
--- a/py/RvText_RandomPrompt.py
+++ b/py/RvText_RandomPrompt.py
@@ -4,7 +4,7 @@ import os
 from ..core import CATEGORY
 
 script_directory = os.path.dirname(__file__)
-folder_path = os.path.join(script_directory, "..\csv" )
+folder_path = os.path.join(script_directory, "..", "csv" )
 
 def getfilename(folder):
     name = []

--- a/py/RvText_RandomPrompt_Chars.py
+++ b/py/RvText_RandomPrompt_Chars.py
@@ -4,7 +4,7 @@ import os
 from ..core import CATEGORY
 
 script_directory = os.path.dirname(__file__)
-folder_path = os.path.join(script_directory, "..\csv1" )
+folder_path = os.path.join(script_directory, "..", "csv1" )
 
 def getfilename(folder):
     name = []

--- a/py/RvText_RandomPrompt_Settings.py
+++ b/py/RvText_RandomPrompt_Settings.py
@@ -4,7 +4,7 @@ import os
 from ..core import CATEGORY
 
 script_directory = os.path.dirname(__file__)
-folder_path = os.path.join(script_directory, "..\csv2" )
+folder_path = os.path.join(script_directory, "..", "csv2" )
 
 def getfilename(folder):
     name = []


### PR DESCRIPTION
There was an issue referencing the folders on a linux filesystems due to the way join was being used.

This commit uses join but seperates the path components so they can be propley joined on different platforms. 

It should now work on both windows, linux and mac.